### PR TITLE
Add support for HTTP proxy

### DIFF
--- a/logziosender.go
+++ b/logziosender.go
@@ -83,6 +83,7 @@ func New(token string, options ...SenderOptionFunc) (*LogzioSender, error) {
 
 	tlsConfig := &tls.Config{}
 	transport := &http.Transport{
+		Proxy: http.ProxyFromEnvironment,
 		TLSClientConfig: tlsConfig,
 	}
 	// in case server side is sleeping - wait 10s instead of waiting for him to wake up


### PR DESCRIPTION
By default Go HTTP custom transport, do not support HTTP(s) proxies, unless Proxy field will be set. 
For example, default Go transport has it https://github.com/golang/go/blob/release-branch.go1.12/src/net/http/transport.go#L42

Thank you.