### PR TITLE
added set http client option

### DIFF
--- a/logziosender.go
+++ b/logziosender.go
@@ -130,6 +130,14 @@ func New(token string, options ...SenderOptionFunc) (*LogzioSender, error) {
 	return l, nil
 }
 
+// SetHttpClient to change the default http client
+func SetHttpClient(client *http.Client) SenderOptionFunc {
+	return func(l *LogzioSender) error {
+		l.httpClient = client
+		return nil
+	}
+}
+
 // SetlogCountLimit to change the default limit
 func SetlogCountLimit(limit int) SenderOptionFunc {
 	return func(l *LogzioSender) error {


### PR DESCRIPTION
In case of running behind a company proxy with its own CA logzioSender will not work with its default client. added setHttpCLient to override the default client and be able to send using my own defined client.  
@yotamloe 