### PR TITLE
Don't ignore error from http.NewRequest

### DIFF
--- a/logziosender.go
+++ b/logziosender.go
@@ -297,6 +297,10 @@ func (l *LogzioSender) makeHttpRequest(data bytes.Buffer, attempt int, c bool) i
 		lost = "0"
 	}
 	req, err := http.NewRequest("POST", l.url, &data)
+	if err != nil {
+		l.debugLog("sender: Error creating HTTP request for %s %s\n", l.url, err)
+		return httpError
+	}
 	req.Header.Add("Content-Type", "text/plain")
 	req.Header.Add("logzio-shipper", fmt.Sprintf("logzio-go/v1.0.0/%d/%s", attempt, lost))
 	if c {


### PR DESCRIPTION
## Description 

This PR stops ignoring an error, which lead to a nil pointer dereference in my app:

```
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x38 pc=0xc707bb]

goroutine 1 [running]:
github.com/logzio/logzio-go.(*LogzioSender).makeHttpRequest(0xc0000b48f0, {{0xc0001eaa00, 0x19b, 0x200}, 0x0, 0x0}, 0x0, 0x1)
    /go/pkg/mod/github.com/logzio/logzio-go@v1.0.8/logziosender.go:300 +0x19b
github.com/logzio/logzio-go.(*LogzioSender).tryToSendLogs(0xc0000b48f0, 0x0)
    /go/pkg/mod/github.com/logzio/logzio-go@v1.0.8/logziosender.go:332 +0xe5
github.com/logzio/logzio-go.(*LogzioSender).Drain(0xc0000b48f0)
    /go/pkg/mod/github.com/logzio/logzio-go@v1.0.8/logziosender.go:389 +0x28b
github.com/logzio/logzio-go.(*LogzioSender).Stop(0xc0000b48f0)
    /go/pkg/mod/github.com/logzio/logzio-go@v1.0.8/logziosender.go:286 +0x56
gitlab.com/packthathouse/backend.git/internal/slog/logzio.(*Handler).Close(...)
    /app/internal/slog/logzio/logzio.go:74
main.run.func1()
    /app/cmd/backend/backend.go:46 +0x3e
main.run()
    /app/cmd/backend/backend.go:53 +0x59a
main.main()
    /app/cmd/backend/backend.go:27 +0x13
```

No attempt yet to determine why the request was returning an error.  One step at a time, and this looks like an obvious oversight regardless of the root cause.


## What type of PR is this?
#### (check all applicable)
- [ ] 🍕 Feature 
- [x] 🐛 Bug Fix
- [ ] 🧑‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [ ] ✅ Test
- [ ] 🤖 Build / CI
- [ ] ⏩ Revert

## Added tests?

- [ ] 👍 yes
- [x] 🙅 no, because they aren't needed
- [ ] 🙋 no, because I need help from somebody
