### PR TITLE
Add SetErrorOutput option and emit delivery failures at error level

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,6 +102,9 @@ func main() {
 - Set debug mode:
     `logzio.New(token, SetDebug(os.Stderr))`
 
+- Set error output. Transport/network failures, non-retryable HTTP responses and dropped logs are written here at error level (independently of debug mode). Defaults to `os.Stderr`; pass `nil` to silence:
+    `logzio.New(token, SetErrorOutput(os.Stderr))`
+
 - Set queue dir:
     `logzio.New(token, SetSetTempDirectory(os.Stderr))`
 
@@ -159,6 +162,10 @@ This project is licensed under the Apache License - see the [LICENSE](LICENSE) f
 
 
 ## Changelog 
+- v1.0.10
+    - Add `SetErrorOutput(io.Writer)` option to direct error-level messages to a configurable writer (defaults to `os.Stderr`; pass `nil` to silence).
+    - Emit transport/network send failures, non-retryable HTTP responses (400/401/403/404) and dropped-log events at error level instead of only debug level.
+    - **Behavior change:** these failure and dropped-log events were previously logged via `debug` and only appeared when `SetDebug` was enabled. They are now written to `os.Stderr` by default, so after upgrading you may see new stderr output on transient send failures and queue drops. To silence error output entirely, pass `logzio.SetErrorOutput(nil)`; to redirect it, pass your own `io.Writer`.
 - v1.0.9
     - Update dependencies:
       - `github.com/shirou/gopsutil/v3`: `v3.24.2` -> `v3.24.5`

--- a/logsender_test.go
+++ b/logsender_test.go
@@ -15,10 +15,12 @@
 package logzio
 
 import (
+	"bytes"
 	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"os"
+	"strings"
 	"testing"
 	"time"
 )
@@ -57,6 +59,95 @@ func TestLogzioSender_SetUrl(t *testing.T) {
 	if l2.url != "http://localhost:12345/?token=token" {
 		t.Fatalf("url should be http://localhost:12345/?token=token, actual: %s", l.url)
 	}
+}
+
+func TestLogzioSender_ErrorOutputDefault(t *testing.T) {
+	l, err := New(
+		"fake-token",
+		SetUrl("http://localhost:12345"),
+		SetInMemoryQueue(true),
+		SetDrainDuration(time.Minute),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer l.Stop()
+	if l.errorOutput != os.Stderr {
+		t.Fatalf("errorOutput should default to os.Stderr")
+	}
+}
+
+func TestLogzioSender_SetErrorOutput(t *testing.T) {
+	var buf bytes.Buffer
+	l, err := New(
+		"fake-token",
+		SetErrorOutput(&buf),
+		SetUrl("http://localhost:12345"),
+		SetInMemoryQueue(true),
+		SetDrainDuration(time.Minute),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer l.Stop()
+	if l.errorOutput != &buf {
+		t.Fatalf("errorOutput should be the writer passed to SetErrorOutput")
+	}
+}
+
+// A non-retryable HTTP failure must surface on the error output, even when
+// debug logging is disabled.
+func TestLogzioSender_ErrorOutputOnUnauth(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusUnauthorized)
+	}))
+	defer ts.Close()
+
+	var buf bytes.Buffer
+	l, err := New(
+		"fake-token",
+		SetErrorOutput(&buf),
+		SetUrl(ts.URL),
+		SetInMemoryQueue(true),
+		SetCompress(false),
+		SetDrainDuration(time.Minute),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer l.Stop()
+
+	l.Send([]byte("blah"))
+	l.Drain()
+
+	out := buf.String()
+	if !strings.Contains(out, "unauthorized") {
+		t.Fatalf("expected unauthorized error on error output, got: %q", out)
+	}
+}
+
+// SetErrorOutput(nil) silences error output without panicking.
+func TestLogzioSender_ErrorOutputNilSilences(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusUnauthorized)
+	}))
+	defer ts.Close()
+
+	l, err := New(
+		"fake-token",
+		SetErrorOutput(nil),
+		SetUrl(ts.URL),
+		SetInMemoryQueue(true),
+		SetCompress(false),
+		SetDrainDuration(time.Minute),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer l.Stop()
+
+	l.Send([]byte("blah"))
+	l.Drain() // must not panic with a nil error writer
 }
 
 // In memory queue tests

--- a/logziosender.go
+++ b/logziosender.go
@@ -59,6 +59,7 @@ type LogzioSender struct {
 	token          string
 	url            string
 	debug          io.Writer
+	errorOutput    io.Writer
 	diskThreshold  float32
 	checkDiskSpace bool
 	dir            string
@@ -84,6 +85,7 @@ func New(token string, options ...SenderOptionFunc) (*LogzioSender, error) {
 		url:            fmt.Sprintf("%s/?token=%s", defaultHost, token),
 		token:          token,
 		dir:            fmt.Sprintf("%s%s%s%s%d", os.TempDir(), string(os.PathSeparator), "logzio-buffer", string(os.PathSeparator), time.Now().UnixNano()),
+		errorOutput:    os.Stderr,
 		diskThreshold:  defaultDiskThreshold,
 		checkDiskSpace: defaultCheckDiskSpace,
 		compress:       true,
@@ -197,6 +199,16 @@ func SetDebug(debug io.Writer) SenderOptionFunc {
 	}
 }
 
+// SetErrorOutput sets the writer that receives error-level messages such as
+// transport/network failures, non-retryable HTTP responses and dropped logs.
+// It defaults to os.Stderr. Pass nil to silence error output entirely.
+func SetErrorOutput(errorOutput io.Writer) SenderOptionFunc {
+	return func(l *LogzioSender) error {
+		l.errorOutput = errorOutput
+		return nil
+	}
+}
+
 // SetDrainDuration to change the interval between drains
 func SetDrainDuration(duration time.Duration) SenderOptionFunc {
 	return func(l *LogzioSender) error {
@@ -237,7 +249,7 @@ func (l *LogzioSender) isEnoughDiskSpace() bool {
 
 		usage := float32(diskStat.UsedPercent)
 		if usage > l.diskThreshold {
-			l.debugLog("sender: Dropping logs, as FS used space on %s is %g percent,"+
+			l.errorLog("sender: Dropping logs, as FS used space on %s is %g percent,"+
 				" and the drop threshold is %g percent\n",
 				l.dir, usage, l.diskThreshold)
 			l.droppedLogs++
@@ -253,7 +265,7 @@ func (l *LogzioSender) isEnoughDiskSpace() bool {
 func (l *LogzioSender) isEnoughMemory(dataSize uint64) bool {
 	usage := l.queue.Length()
 	if usage+dataSize >= l.inMemoryCapacity {
-		l.debugLog("sender: Dropping logs, the max capacity is %d and %d is requested, Request size: %d\n", l.inMemoryCapacity, usage+dataSize, dataSize)
+		l.errorLog("sender: Dropping logs, the max capacity is %d and %d is requested, Request size: %d\n", l.inMemoryCapacity, usage+dataSize, dataSize)
 		l.droppedLogs++
 		return false
 	} else {
@@ -298,7 +310,7 @@ func (l *LogzioSender) makeHttpRequest(data bytes.Buffer, attempt int, c bool) i
 	}
 	req, err := http.NewRequest("POST", l.url, &data)
 	if err != nil {
-		l.debugLog("sender: Error creating HTTP request for %s %s\n", l.url, err)
+		l.errorLog("sender: Error creating HTTP request for %s %s\n", l.url, err)
 		return httpError
 	}
 	req.Header.Add("Content-Type", "text/plain")
@@ -309,7 +321,7 @@ func (l *LogzioSender) makeHttpRequest(data bytes.Buffer, attempt int, c bool) i
 	l.debugLog("sender: Sending bulk of %v bytes\n", l.buf.Len())
 	resp, err := l.httpClient.Do(req)
 	if err != nil {
-		l.debugLog("sender: Error sending logs to %s %s\n", l.url, err)
+		l.errorLog("sender: Error sending logs to %s %s\n", l.url, err)
 		return httpError
 	}
 
@@ -350,16 +362,16 @@ func (l *LogzioSender) shouldRetry(statusCode int) bool {
 	retry := true
 	switch statusCode {
 	case http.StatusBadRequest:
-		l.debugLog("sender: Got HTTP %d bad request, skip retry\n", statusCode)
+		l.errorLog("sender: Got HTTP %d bad request, skip retry\n", statusCode)
 		retry = false
 	case http.StatusNotFound:
-		l.debugLog("sender: Got HTTP %d not found, skip retry\n", statusCode)
+		l.errorLog("sender: Got HTTP %d not found, skip retry\n", statusCode)
 		retry = false
 	case http.StatusUnauthorized:
-		l.debugLog("sender: Got HTTP %d unauthorized, skip retry\n", statusCode)
+		l.errorLog("sender: Got HTTP %d unauthorized, skip retry\n", statusCode)
 		retry = false
 	case http.StatusForbidden:
-		l.debugLog("sender: Got HTTP %d forbidden, skip retry\n", statusCode)
+		l.errorLog("sender: Got HTTP %d forbidden, skip retry\n", statusCode)
 		retry = false
 	case http.StatusOK:
 		retry = false
@@ -453,7 +465,9 @@ func (l *LogzioSender) debugLog(format string, a ...interface{}) {
 }
 
 func (l *LogzioSender) errorLog(format string, a ...interface{}) {
-	fmt.Fprintf(os.Stderr, format, a...)
+	if l.errorOutput != nil {
+		fmt.Fprintf(l.errorOutput, format, a...)
+	}
 }
 
 func (l *LogzioSender) Write(p []byte) (n int, err error) {


### PR DESCRIPTION
…evel

## Description 

Add a configurable `errorOutput io.Writer` (SetErrorOutput, default os.Stderr, nil to silence) and route transport/network failures, non-retryable HTTP responses 400/401/403/404), and dropped-log events from debugLog to errorLog, so delivery failures are visible without enabling full debug output.

## What type of PR is this?
#### (check all applicable)
- [x] 🍕 Feature 
- [ ] 🐛 Bug Fix
- [ ] 🧑‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [ ] ✅ Test
- [ ] 🤖 Build / CI
- [ ] ⏩ Revert

## Added tests?

- [x] 👍 yes
- [ ] 🙅 no, because they aren't needed
- [ ] 🙋 no, because I need help from somebody
